### PR TITLE
Bump cniplugins version to v1.6.2-build20250124

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH=${TARGETARCH}
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
 ARG GO_IMAGE=rancher/hardened-build-base:v1.23.4b1
-ARG CNI_IMAGE_VERSION=v1.6.2-build20250108
+ARG CNI_IMAGE_VERSION=v1.6.2-build20250124
 ARG CNI_IMAGE=rancher/hardened-cni-plugins:${CNI_IMAGE_VERSION}
 ARG GOEXPERIMENT=boringcrypto
 


### PR DESCRIPTION



<Actions>
    <action id="ae7fb6bad24766ccc67f167aff03300fa580cb0d355bc577190ad320785eb6d4">
        <h3>Update cniplugins version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump to latest cniplugins version in Dockerfile</summary>
            <p>changed lines [4] of file &#34;/tmp/updatecli/github/mgfritch/image-build-calico/Dockerfile&#34;</p>
            <details>
                <summary>v1.6.2-build20250124</summary>
                <pre>&#xA;Release published on the 2025-01-24 11:23:35 +0000 UTC at the url https://github.com/rancher/image-build-cni-plugins/releases/tag/v1.6.2-build20250124&#xA;&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

